### PR TITLE
Fix Dockerfile

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk/openjdk11:slim
 VOLUME /tmp
-ADD ./target/ofac-1.0.0.jar app.jar
+ADD ./target/ofac-opensource-1.0.0.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 8080
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
Maven artifacts generates **"ofac-opensource-1.0.0.jar"** instead of **"ofac-1.0.0.jar"**